### PR TITLE
specify argparse port argument as int

### DIFF
--- a/saleae_cli.py
+++ b/saleae_cli.py
@@ -16,7 +16,7 @@ parser.add_argument('--save-captures', metavar='PATH', help='if specified, saves
 parser.add_argument('--export-data', metavar='PATH', help='if specified, exports the raw capture to the sepcified directory')
 parser.add_argument('--export-analyzers', metavar='PATH', help='if specified, exports each analyzer to the specified directory')
 parser.add_argument('--ip', metavar='IP', default='localhost', help='optional, IP address to connect to. Default localhost')
-parser.add_argument('--port', metavar='PORT', default=10429, help='optional, Port to connect to. Default 10429')
+parser.add_argument('--port', metavar='PORT', default=10429, type=int, help='optional, Port to connect to. Default 10429')
 parser.add_argument('--exit', action='store_true', help='optional, use to close the Logic software once complete')
 
 args = parser.parse_args()


### PR DESCRIPTION
background: the constructor of the Saleae class requires that the port
argument being provided is an integer, otherwise the construction fails
and crashes the program. By default, argparse parses arguments as
strings, so previously specifying a port via the CLI would crash the
program. Specifying the port argument as an int in add_argument() solves
this problem.